### PR TITLE
fix: darwin ssh agent

### DIFF
--- a/environments/includes/php-fpm.base.yml
+++ b/environments/includes/php-fpm.base.yml
@@ -6,6 +6,7 @@ x-volumes: &volumes
   - .${ROLL_WEB_ROOT:-}/:/var/www/html:cached
   - bashhistory:/bash_history
   - sshdirectory:/home/www-data/.ssh
+  - ~/.ssh/known_hosts:/home/www-data/known_hosts
 
 x-extra_hosts: &extra_hosts
     - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}

--- a/environments/includes/php-fpm.darwin.yml
+++ b/environments/includes/php-fpm.darwin.yml
@@ -1,7 +1,14 @@
-
 x-volumes: &volumes
   - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
 
 services:
-  php-fpm: { volumes: *volumes }
-  php-debug: { volumes: *volumes }
+  php-fpm:
+    environment:
+      - SSH_AUTH_SOCK=${SSH_AUTH_SOCK_PATH_ENV:/run/host-services/ssh-auth.sock}
+    volumes: 
+      *volumes
+  php-debug:
+    environment:
+      - SSH_AUTH_SOCK=${SSH_AUTH_SOCK_PATH_ENV:/run/host-services/ssh-auth.sock}
+    volumes:
+      *volumes


### PR DESCRIPTION
untested: should resolve issues with forwarding ssh agent to container. relevant in projects that have npm packages from our private repository that require SSH access, currently people are making their own workaround each time the container has restarted but this should resolve it.